### PR TITLE
switch ProcessGroup related API to use intrusive_ptr

### DIFF
--- a/src/ProcessGroupCCL.cpp
+++ b/src/ProcessGroupCCL.cpp
@@ -351,8 +351,8 @@ void ProcessGroupCCL::cclInitOnce()
   });
 }
 
-std::shared_ptr<ProcessGroup> ProcessGroupCCL::createProcessGroupCCL(
-    const std::shared_ptr<Store>& store,
+c10::intrusive_ptr<ProcessGroup> ProcessGroupCCL::createProcessGroupCCL(
+    const c10::intrusive_ptr<Store>& store,
     int rank,
     int size,
     const std::chrono::duration<float>& timeout)
@@ -411,7 +411,7 @@ ProcessGroupCCL::~ProcessGroupCCL()
     comm.reset();
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::broadcast(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::broadcast(
     std::vector<at::Tensor>& tensors,
     const BroadcastOptions& opts)
 {
@@ -615,7 +615,7 @@ ccl_status_t sparseAllreduceAllocFn(
     return ccl_status_success;
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce(
     std::vector<at::Tensor>& tensors,
     const AllreduceOptions& opts)
 {
@@ -626,7 +626,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce(
     checkSingleTensor(tensors);
 
     std::shared_ptr<ccl::request> req;
-    std::shared_ptr<ProcessGroupCCL::WorkCCL> work;
+    c10::intrusive_ptr<ProcessGroupCCL::WorkCCL> work;
 
     {
         std::unique_lock<std::mutex> globalLock(globalMutex);
@@ -679,14 +679,14 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce(
     return work;
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce_coalesced(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce_coalesced(
     std::vector<at::Tensor>& /* unused */,
     const AllreduceCoalescedOptions& /* unused */)
 {
     TORCH_CHECK(false, "ProcessGroupCCL does not support allreduce_coalesced");
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce(
     std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts)
 {
@@ -712,7 +712,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce(
     return std::make_shared<ProcessGroupCCL::WorkCCL>(req, tensors, std::move(debugName));
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const AllgatherOptions& opts)
@@ -776,7 +776,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather(
     return std::make_shared<ProcessGroupCCL::WorkCCL>(req, std::move(agTensors), std::move(debugName));
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather_base(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather_base(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& /* unused */)
@@ -784,7 +784,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather_base(
     TORCH_CHECK(false, "ProcessGroupCCL does not support allgather_base");
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather_coalesced(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather_coalesced(
     std::vector<std::vector<at::Tensor>>& /* unused */,
     std::vector<at::Tensor>& /* unused */,
     const AllgatherOptions& /* unused */)
@@ -792,7 +792,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather_coalesced(
     TORCH_CHECK(false, "ProcessGroupCCL does not support allgather_coalesced");
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::gather(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::gather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const GatherOptions& opts)
@@ -885,7 +885,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::gather(
     return std::make_shared<ProcessGroupCCL::WorkCCL>(req, std::move(gatherTensors), std::move(debugName));
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::scatter(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ScatterOptions& opts)
@@ -965,7 +965,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::scatter(
     return std::make_shared<ProcessGroupCCL::WorkCCL>(req, std::move(scatterTensors), std::move(debugName));
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce_scatter(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce_scatter(
     std::vector<at::Tensor>& /* unused */,
     std::vector<std::vector<at::Tensor>>& /* unused */,
     const ReduceScatterOptions& /* unused */)
@@ -973,7 +973,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce_scatter(
     TORCH_CHECK(false, "ProcessGroupCCL does not support reduce_scatter");
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall_base(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall_base(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,
@@ -1046,7 +1046,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall_base(
     return std::make_shared<ProcessGroupCCL::WorkCCL>(req, std::move(a2aTensors), std::move(debugName));
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const AllToAllOptions& opts)
@@ -1127,7 +1127,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall(
     return std::make_shared<ProcessGroupCCL::WorkCCL>(req, std::move(a2aTensors), std::move(debugName));
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::send(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::send(
     std::vector<at::Tensor>& /* unused */,
     int /* unused */,
     int /* unused */)
@@ -1135,7 +1135,7 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::send(
     TORCH_CHECK(false, "ProcessGroupCCL does not support send");
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::recv(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::recv(
     std::vector<at::Tensor>& /* unused */,
     int /* unused */,
     int /* unused */)
@@ -1143,14 +1143,14 @@ std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::recv(
     TORCH_CHECK(false, "ProcessGroupCCL does not support recv");
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::recvAnysource(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::recvAnysource(
     std::vector<at::Tensor>& /* unused */,
     int /* unused */)
 {
     TORCH_CHECK(false, "ProcessGroupCCL does not support recvAnysource");
 }
 
-std::shared_ptr<ProcessGroup::Work> ProcessGroupCCL::barrier(
+c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::barrier(
     const BarrierOptions& opts)
 {
     RECORD_FUNCTION("pg::barrier", std::vector<c10::IValue>());

--- a/src/ProcessGroupCCL.hpp
+++ b/src/ProcessGroupCCL.hpp
@@ -133,85 +133,85 @@ public:
   explicit ProcessGroupCCL(int rank = -1, int size = -1, const std::vector<int> ranks = {});
   virtual ~ProcessGroupCCL();
 
-  std::shared_ptr<ProcessGroup::Work> broadcast(
+  c10::intrusive_ptr<ProcessGroup::Work> broadcast(
       std::vector<at::Tensor>& data,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> allreduce_coalesced(
+  c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
       std::vector<at::Tensor>& tensors,
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> reduce(
+  c10::intrusive_ptr<ProcessGroup::Work> reduce(
       std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> allgather(
+  c10::intrusive_ptr<ProcessGroup::Work> allgather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> allgather_base(
+  c10::intrusive_ptr<ProcessGroup::Work> allgather_base(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> allgather_coalesced(
+  c10::intrusive_ptr<ProcessGroup::Work> allgather_coalesced(
       std::vector<std::vector<at::Tensor>>& outputTensorLists,
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> gather(
+  c10::intrusive_ptr<ProcessGroup::Work> gather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const GatherOptions& opts = GatherOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> scatter(
+  c10::intrusive_ptr<ProcessGroup::Work> scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> reduce_scatter(
+  c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> alltoall_base(
+  c10::intrusive_ptr<ProcessGroup::Work> alltoall_base(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputSplitSizes,
       std::vector<int64_t>& inputSplitSizes,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> alltoall(
+  c10::intrusive_ptr<ProcessGroup::Work> alltoall(
       std::vector<at::Tensor>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
-  std::shared_ptr<ProcessGroup::Work> send(
+  c10::intrusive_ptr<ProcessGroup::Work> send(
       std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override;
 
-  std::shared_ptr<ProcessGroup::Work> recv(
+  c10::intrusive_ptr<ProcessGroup::Work> recv(
       std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override;
 
-  std::shared_ptr<ProcessGroup::Work> recvAnysource(
+  c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
       std::vector<at::Tensor>& tensor,
       int tag) override;
 
-  std::shared_ptr<ProcessGroup::Work> barrier(
+  c10::intrusive_ptr<ProcessGroup::Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;
 
   // create a new ProcessGroupCCL and initialize CCL if not initialized
-  static std::shared_ptr<ProcessGroup> createProcessGroupCCL(
-      const std::shared_ptr<Store>& store,
+  static c10::intrusive_ptr<ProcessGroup> createProcessGroupCCL(
+      const c10::intrusive_ptr<Store>& store,
       int rank = -1,
       int size = -1,
       const std::chrono::duration<float>& timeout = std::chrono::duration<float>(1));

--- a/tests/ProcessGroupCCLTest.cpp
+++ b/tests/ProcessGroupCCLTest.cpp
@@ -50,15 +50,15 @@
 
 #include "ProcessGroupCCL.hpp"
 
-std::shared_ptr<c10d::ProcessGroup> createProcessGroup()
+c10::intrusive_ptr<c10d::ProcessGroup> createProcessGroup()
 {
     auto store = std::make_shared<c10d::HashStore>();
     std::chrono::duration<float> timeout(1);
     return c10d::ProcessGroupCCL::createProcessGroupCCL(store, -1, -1, std::vector<int>(), timeout);
 }
 
-void waitWork(std::shared_ptr<c10d::ProcessGroup> pg,
-              std::vector<std::shared_ptr<c10d::ProcessGroup::Work>> works)
+void waitWork(c10::intrusive_ptr<c10d::ProcessGroup> pg,
+              std::vector<c10::intrusive_ptr<c10d::ProcessGroup::Work>> works)
 {
     for (auto& work : works)
     {
@@ -113,11 +113,11 @@ void testAllgatherFlat(int iter = 1000)
         }
     }
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (size_t i = 0; i < allInputTensors.size(); ++i)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work =
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work =
             pg->allgather(allOutputTensors[i], allInputTensors[i]);
         works.push_back(std::move(work));
     }
@@ -172,11 +172,11 @@ void testAllgatherNotFlat(int iter = 1000)
         }
     }
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (size_t i = 0; i < allInputTensors.size(); ++i)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work =
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work =
             pg->allgather(allOutputTensors[i], allInputTensors[i]);
         works.push_back(std::move(work));
     }
@@ -224,11 +224,11 @@ void testAllreduce(int iter = 1000)
         allTensors[i] = std::vector<at::Tensor>({tensor});
     }
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (auto& tensors : allTensors)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work = pg->allreduce(tensors);
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work = pg->allreduce(tensors);
         works.push_back(std::move(work));
     }
 
@@ -305,11 +305,11 @@ void testSparseAllreduce(int iter = 50)
         allTensors[i] = std::vector<at::Tensor>({tensor});
     }
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (auto& tensors : allTensors)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work = pg->allreduce(tensors);
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work = pg->allreduce(tensors);
         works.push_back(std::move(work));
     }
 
@@ -420,12 +420,12 @@ void testAlltoallBase(int iter = 1000)
     }
 
     std::vector<int64_t> splitSizes;
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
 
     for (size_t i = 0; i < allInputTensors.size(); ++i)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work =
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work =
             pg->alltoall_base(allOutputTensors[i], allInputTensors[i],
                               splitSizes, splitSizes);
         works.push_back(std::move(work));
@@ -492,11 +492,11 @@ void testAlltoallFlat(int iter = 1000)
         }
     }
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (size_t i = 0; i < allInputTensors.size(); ++i)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work =
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work =
             pg->alltoall(allOutputTensors[i], allInputTensors[i]);
         works.push_back(std::move(work));
     }
@@ -555,11 +555,11 @@ void testAlltoallNonFlat(int iter = 1000)
         }
     }
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (size_t i = 0; i < allInputTensors.size(); ++i)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work =
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work =
             pg->alltoall(allOutputTensors[i], allInputTensors[i]);
         works.push_back(std::move(work));
     }
@@ -598,11 +598,11 @@ void testBarrier(int iter = 1000)
 
     auto rank = pg->getRank();
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (auto i = 0; i < iter; ++i)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work = pg->barrier();
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work = pg->barrier();
         works.push_back(std::move(work));
     }
 
@@ -637,11 +637,11 @@ void testBroadcast(int iter = 1000)
         }
     }
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (auto& tensors : allTensors)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work = pg->broadcast(tensors);
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work = pg->broadcast(tensors);
         works.push_back(std::move(work));
     }
 
@@ -701,12 +701,12 @@ void testGather(int iter = 1000)
     c10d::GatherOptions gatherOptions;
     gatherOptions.rootRank = rootRank;
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
 
     for (size_t i = 0; i < allInputTensors.size(); ++i)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work =
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work =
             pg->gather(allOutputTensors[i], allInputTensors[i], gatherOptions);
         works.push_back(std::move(work));
     }
@@ -756,11 +756,11 @@ void testReduce(int iter = 1000)
         allTensors[i] = std::vector<at::Tensor>({tensor});
     }
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (auto& tensors : allTensors)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work = pg->reduce(tensors);
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work = pg->reduce(tensors);
         works.push_back(std::move(work));
     }
 
@@ -828,11 +828,11 @@ void testScatter(int iter = 1000)
     c10d::ScatterOptions scatterOptions;
     scatterOptions.rootRank = rootRank;
 
-    std::vector<std::shared_ptr<::c10d::ProcessGroup::Work>> works;
+    std::vector<c10::intrusive_ptr<::c10d::ProcessGroup::Work>> works;
     for (size_t i = 0; i < allInputTensors.size(); ++i)
     {
         // Kick off work
-        std::shared_ptr<::c10d::ProcessGroup::Work> work =
+        c10::intrusive_ptr<::c10d::ProcessGroup::Work> work =
             pg->scatter(allOutputTensors[i], allInputTensors[i], scatterOptions);
         works.push_back(std::move(work));
     }


### PR DESCRIPTION
Hi torch-ccl maintainers, I am currently trying to land https://github.com/pytorch/pytorch/pull/47343, which consists of a series of ProcessGroup C++ API changes, created this PR to ensure we don't break third_party extension APIs in ccl repo. Let me know if you have any questions/concerns. Thanks!