### PR TITLE
[PT 1.13] Update ProcessGroup::Work references to Work

### DIFF
--- a/src/ProcessGroupCCL.cpp
+++ b/src/ProcessGroupCCL.cpp
@@ -92,7 +92,7 @@ ProcessGroupCCL::AsyncWorkCCL::AsyncWorkCCL(std::vector<std::vector<at::Tensor>>
 // Profiler: Pass nullptr as profilingTitle to parent constructor to
 // replace default profiler implementation with async version that reports
 // correct timestamps for work that is asynchronously executed.
-        : ProcessGroup::Work(rank, opType, profilingTitle, inputTensors),
+        : Work(rank, opType, profilingTitle, inputTensors),
           outputTensors_(std::move(outputTensors)),
           future_(createFutureAsOutput(outputTensors)) {
 //  if (profilingTitle != nullptr) {
@@ -177,7 +177,7 @@ ProcessGroupCCL::~ProcessGroupCCL()
 {
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::broadcast(
+c10::intrusive_ptr<Work> ProcessGroupCCL::broadcast(
     std::vector<at::Tensor>& tensors,
     const BroadcastOptions& opts)
 {
@@ -191,7 +191,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::broadcast(
   return work;
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce(
+c10::intrusive_ptr<Work> ProcessGroupCCL::allreduce(
   std::vector<at::Tensor>& tensors,
   const AllreduceOptions& opts)
 {
@@ -203,14 +203,14 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce(
   return work;
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allreduce_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupCCL::allreduce_coalesced(
     std::vector<at::Tensor>& /* unused */,
     const AllreduceCoalescedOptions& /* unused */)
 {
   TORCH_CHECK(false, "ProcessGroupCCL does not support allreduce_coalesced");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce(
+c10::intrusive_ptr<Work> ProcessGroupCCL::reduce(
     std::vector<at::Tensor>& tensors,
     const ReduceOptions& opts)
 {
@@ -224,7 +224,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce(
 }
 
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather(
+c10::intrusive_ptr<Work> ProcessGroupCCL::allgather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const AllgatherOptions& opts)
@@ -238,7 +238,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather(
   return work;
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::_allgather_base(
+c10::intrusive_ptr<Work> ProcessGroupCCL::_allgather_base(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& /* unused */)
@@ -246,7 +246,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::_allgather_base(
   TORCH_CHECK(false, "ProcessGroupCCL does not support _allgather_base");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather_coalesced(
+c10::intrusive_ptr<Work> ProcessGroupCCL::allgather_coalesced(
     std::vector<std::vector<at::Tensor>>& /* unused */,
     std::vector<at::Tensor>& /* unused */,
     const AllgatherOptions& /* unused */)
@@ -254,7 +254,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::allgather_coalesced(
   TORCH_CHECK(false, "ProcessGroupCCL does not support allgather_coalesced");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::gather(
+c10::intrusive_ptr<Work> ProcessGroupCCL::gather(
     std::vector<std::vector<at::Tensor>>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const GatherOptions& opts)
@@ -268,7 +268,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::gather(
   return work;
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::scatter(
+c10::intrusive_ptr<Work> ProcessGroupCCL::scatter(
     std::vector<at::Tensor>& outputTensors,
     std::vector<std::vector<at::Tensor>>& inputTensors,
     const ScatterOptions& opts)
@@ -282,7 +282,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::scatter(
   return work;
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce_scatter(
+c10::intrusive_ptr<Work> ProcessGroupCCL::reduce_scatter(
     std::vector<at::Tensor>& /* unused */,
     std::vector<std::vector<at::Tensor>>& /* unused */,
     const ReduceScatterOptions& /* unused */)
@@ -290,7 +290,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::reduce_scatter(
   TORCH_CHECK(false, "ProcessGroupCCL does not support reduce_scatter");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall_base(
+c10::intrusive_ptr<Work> ProcessGroupCCL::alltoall_base(
     at::Tensor& outputTensor,
     at::Tensor& inputTensor,
     std::vector<int64_t>& outputSplitSizes,
@@ -306,7 +306,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall_base(
   return work;
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall(
+c10::intrusive_ptr<Work> ProcessGroupCCL::alltoall(
     std::vector<at::Tensor>& outputTensors,
     std::vector<at::Tensor>& inputTensors,
     const AllToAllOptions& opts)
@@ -320,7 +320,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::alltoall(
   return work;
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::send(
+c10::intrusive_ptr<Work> ProcessGroupCCL::send(
     std::vector<at::Tensor>& /* unused */,
     int /* unused */,
     int /* unused */)
@@ -328,7 +328,7 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::send(
   TORCH_CHECK(false, "ProcessGroupCCL does not support send");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::recv(
+c10::intrusive_ptr<Work> ProcessGroupCCL::recv(
     std::vector<at::Tensor>& /* unused */,
     int /* unused */,
     int /* unused */)
@@ -336,14 +336,14 @@ c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::recv(
   TORCH_CHECK(false, "ProcessGroupCCL does not support recv");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::recvAnysource(
+c10::intrusive_ptr<Work> ProcessGroupCCL::recvAnysource(
     std::vector<at::Tensor>& /* unused */,
     int /* unused */)
 {
   TORCH_CHECK(false, "ProcessGroupCCL does not support recvAnysource");
 }
 
-c10::intrusive_ptr<ProcessGroup::Work> ProcessGroupCCL::barrier(
+c10::intrusive_ptr<Work> ProcessGroupCCL::barrier(
     const BarrierOptions& opts)
 {
  return DispatchStub::barrier(opts, *this);

--- a/src/ProcessGroupCCL.hpp
+++ b/src/ProcessGroupCCL.hpp
@@ -74,7 +74,7 @@ class ProcessGroupCCL : public ProcessGroup
 {
 
 public:
-  class AsyncWorkCCL : public ProcessGroup::Work {
+  class AsyncWorkCCL : public Work {
   public:
     AsyncWorkCCL(std::vector<std::vector<at::Tensor>> outputTensors,
                  int rank = -1,
@@ -114,80 +114,80 @@ public:
   }
 #endif
 
-  c10::intrusive_ptr<ProcessGroup::Work> broadcast(
+  c10::intrusive_ptr<Work> broadcast(
       std::vector<at::Tensor>& data,
       const BroadcastOptions& opts = BroadcastOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce(
+  c10::intrusive_ptr<Work> allreduce(
       std::vector<at::Tensor>& tensors,
       const AllreduceOptions& opts = AllreduceOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allreduce_coalesced(
+  c10::intrusive_ptr<Work> allreduce_coalesced(
       std::vector<at::Tensor>& tensors,
       const AllreduceCoalescedOptions& opts =
           AllreduceCoalescedOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> reduce(
+  c10::intrusive_ptr<Work> reduce(
       std::vector<at::Tensor>& tensors,
       const ReduceOptions& opts = ReduceOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allgather(
+  c10::intrusive_ptr<Work> allgather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> _allgather_base(
+  c10::intrusive_ptr<Work> _allgather_base(
       at::Tensor& outputBuffer,
       at::Tensor& inputBuffer,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> allgather_coalesced(
+  c10::intrusive_ptr<Work> allgather_coalesced(
       std::vector<std::vector<at::Tensor>>& outputTensorLists,
       std::vector<at::Tensor>& inputTensors,
       const AllgatherOptions& opts = AllgatherOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> gather(
+  c10::intrusive_ptr<Work> gather(
       std::vector<std::vector<at::Tensor>>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const GatherOptions& opts = GatherOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> scatter(
+  c10::intrusive_ptr<Work> scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ScatterOptions& opts = ScatterOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> reduce_scatter(
+  c10::intrusive_ptr<Work> reduce_scatter(
       std::vector<at::Tensor>& outputTensors,
       std::vector<std::vector<at::Tensor>>& inputTensors,
       const ReduceScatterOptions& opts = ReduceScatterOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> alltoall_base(
+  c10::intrusive_ptr<Work> alltoall_base(
       at::Tensor& outputTensor,
       at::Tensor& inputTensor,
       std::vector<int64_t>& outputSplitSizes,
       std::vector<int64_t>& inputSplitSizes,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> alltoall(
+  c10::intrusive_ptr<Work> alltoall(
       std::vector<at::Tensor>& outputTensors,
       std::vector<at::Tensor>& inputTensors,
       const AllToAllOptions& opts = AllToAllOptions()) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> send(
+  c10::intrusive_ptr<Work> send(
       std::vector<at::Tensor>& tensors,
       int dstRank,
       int tag) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> recv(
+  c10::intrusive_ptr<Work> recv(
       std::vector<at::Tensor>& tensors,
       int srcRank,
       int tag) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> recvAnysource(
+  c10::intrusive_ptr<Work> recvAnysource(
       std::vector<at::Tensor>& tensor,
       int tag) override;
 
-  c10::intrusive_ptr<ProcessGroup::Work> barrier(
+  c10::intrusive_ptr<Work> barrier(
       const BarrierOptions& opts = BarrierOptions()) override;
 
   // create a new ProcessGroupCCL and initialize CCL if not initialized


### PR DESCRIPTION
### Context
Hi, I am a developer on the PyTorch Distributed team. We recently performed refactoring to move the `Work` object out of the `ProcessGroup` class (https://github.com/pytorch/pytorch/pull/83680). This change in currently in the nightly build and will be introduced in the 1.13 release. Filing this PR so that this extension will also continue to work.

### Changes
Update all references to `ProcessGroup::Work` to `Work`.

### Testing Plan
Built extension with `python setup.py install` successfully